### PR TITLE
updating hapi and request

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.14.1",
   "dependencies": {
     "bluebird": {
-      "version": "2.2.1",
-      "from": "bluebird@2.2.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.1.tgz"
+      "version": "2.2.2",
+      "from": "bluebird@2.2.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.2.2.tgz"
     },
     "convict": {
       "version": "0.4.2",
@@ -29,23 +29,28 @@
                   "dependencies": {
                     "underscore": {
                       "version": "1.6.0",
-                      "from": "underscore@~1.6.0"
+                      "from": "underscore@~1.6.0",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     },
                     "chalk": {
                       "version": "0.4.0",
                       "from": "chalk@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "from": "has-color@~0.1.0"
+                          "from": "has-color@~0.1.0",
+                          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                         },
                         "ansi-styles": {
                           "version": "1.0.0",
-                          "from": "ansi-styles@~1.0.0"
+                          "from": "ansi-styles@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
-                          "from": "strip-ansi@~0.1.0"
+                          "from": "strip-ansi@~0.1.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
                     }
@@ -53,7 +58,8 @@
                 },
                 "JSV": {
                   "version": "4.0.2",
-                  "from": "JSV@>= 4.0.x"
+                  "from": "JSV@>= 4.0.x",
+                  "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
             }
@@ -76,246 +82,265 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@~0.0.2"
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1"
+              "from": "minimist@~0.0.1",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         }
       }
     },
     "hapi": {
-      "version": "6.2.0",
-      "from": "https://registry.npmjs.org/hapi/-/hapi-6.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-6.2.0.tgz",
+      "version": "6.4.0",
+      "from": "hapi@6.4.0",
+      "resolved": "https://registry.npmjs.org/hapi/-/hapi-6.4.0.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.3.0",
-          "from": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.3.0.tgz"
+          "version": "2.4.1",
+          "from": "hoek@^2.3.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.4.1.tgz"
         },
         "boom": {
-          "version": "2.4.2",
-          "from": "https://registry.npmjs.org/boom/-/boom-2.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.4.2.tgz"
+          "version": "2.5.0",
+          "from": "boom@^2.4.x",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.5.0.tgz"
         },
         "catbox": {
-          "version": "2.2.1",
-          "from": "https://registry.npmjs.org/catbox/-/catbox-2.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/catbox/-/catbox-2.2.1.tgz"
+          "version": "3.1.0",
+          "from": "catbox@^3.1.x",
+          "resolved": "https://registry.npmjs.org/catbox/-/catbox-3.1.0.tgz"
         },
         "catbox-memory": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.0.3.tgz"
+          "version": "1.0.4",
+          "from": "catbox-memory@1.x.x",
+          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.0.4.tgz"
         },
         "shot": {
-          "version": "1.3.3",
-          "from": "https://registry.npmjs.org/shot/-/shot-1.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/shot/-/shot-1.3.3.tgz"
+          "version": "1.3.4",
+          "from": "shot@1.x.x",
+          "resolved": "https://registry.npmjs.org/shot/-/shot-1.3.4.tgz"
         },
         "nipple": {
-          "version": "2.5.3",
-          "from": "https://registry.npmjs.org/nipple/-/nipple-2.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/nipple/-/nipple-2.5.3.tgz"
+          "version": "2.5.4",
+          "from": "nipple@^2.4.x",
+          "resolved": "https://registry.npmjs.org/nipple/-/nipple-2.5.4.tgz"
         },
         "cryptiles": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.1.tgz"
+          "version": "2.0.2",
+          "from": "cryptiles@2.x.x",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.2.tgz"
         },
         "iron": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/iron/-/iron-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.0.tgz"
+          "version": "2.1.1",
+          "from": "iron@2.x.x",
+          "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.1.tgz"
         },
         "topo": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "topo@1.x.x",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.1.tgz"
         },
         "kilt": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/kilt/-/kilt-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.0.tgz"
+          "version": "1.1.1",
+          "from": "kilt@^1.1.x",
+          "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz"
         },
         "async": {
-          "version": "0.8.0",
-          "from": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz"
+          "version": "0.9.0",
+          "from": "async@0.9.x",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "multiparty": {
           "version": "3.2.10",
-          "from": "https://registry.npmjs.org/multiparty/-/multiparty-3.2.10.tgz",
+          "from": "multiparty@3.2.x",
           "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.2.10.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13-1",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+              "from": "readable-stream@~1.1.9",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.25-1",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "stream-counter": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+              "from": "stream-counter@~0.2.0",
               "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
             }
           }
         },
         "mime": {
           "version": "1.2.11",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "from": "mime@1.2.x",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "lru-cache": {
           "version": "2.5.0",
-          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+          "from": "lru-cache@2",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@0.6.x",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "negotiator": {
           "version": "0.4.7",
-          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz",
+          "from": "negotiator@0.4.x",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
         },
         "semver": {
-          "version": "2.3.1",
-          "from": "https://registry.npmjs.org/semver/-/semver-2.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.1.tgz"
+          "version": "2.3.2",
+          "from": "semver@2.3.x",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "qs": {
-          "version": "0.6.6",
-          "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+          "version": "1.2.0",
+          "from": "qs@1.x.x",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz"
         }
       }
     },
     "intel": {
       "version": "1.0.0-b4",
       "from": "intel@1.0.0-b4",
+      "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.0-b4.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
           "from": "chalk@~0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0"
+              "from": "ansi-styles@^1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.0",
-              "from": "escape-string-regexp@^1.0.0"
+              "version": "1.0.1",
+              "from": "escape-string-regexp@^1.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.1.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
               "from": "has-ansi@^0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0"
+                  "from": "ansi-regex@^0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
               "from": "strip-ansi@^0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0"
+                  "from": "ansi-regex@^0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0"
+              "from": "supports-color@^0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
         },
         "dbug": {
           "version": "0.4.1",
-          "from": "dbug@~0.4.1"
+          "from": "dbug@~0.4.1",
+          "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.1.tgz"
         },
         "stack-trace": {
           "version": "0.0.9",
-          "from": "stack-trace@~0.0.9"
+          "from": "stack-trace@~0.0.9",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
         },
         "strftime": {
           "version": "0.8.1",
-          "from": "strftime@~0.8.0"
+          "from": "strftime@~0.8.0",
+          "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.1.tgz"
         },
         "symbol": {
           "version": "0.2.1",
-          "from": "symbol@~0.2.0"
+          "from": "symbol@~0.2.0",
+          "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.1.tgz"
         },
         "utcstring": {
           "version": "0.1.0",
-          "from": "utcstring@~0.1.0"
+          "from": "utcstring@~0.1.0",
+          "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
         }
       }
     },
     "joi": {
-      "version": "4.6.1",
-      "from": "joi@4.6.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-4.6.1.tgz",
+      "version": "4.6.2",
+      "from": "joi@4.6.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-4.6.2.tgz",
       "dependencies": {
         "hoek": {
-          "version": "2.3.0",
-          "from": "hoek@^2.2.x"
+          "version": "2.4.1",
+          "from": "hoek@^2.2.x",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.4.1.tgz"
         },
         "topo": {
-          "version": "1.0.0",
-          "from": "topo@1.x.x"
+          "version": "1.0.1",
+          "from": "topo@1.x.x",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.1.tgz"
         },
         "isemail": {
           "version": "1.0.1",
-          "from": "isemail@1.x.x"
+          "from": "isemail@1.x.x",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.0.1.tgz"
         }
       }
     },
     "mysql": {
-      "version": "2.3.2",
-      "from": "mysql@2.3.2",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.3.2.tgz",
+      "version": "2.4.2",
+      "from": "mysql@2.4.2",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.4.2.tgz",
       "dependencies": {
         "bignumber.js": {
           "version": "1.4.0",
@@ -324,11 +349,13 @@
         },
         "readable-stream": {
           "version": "1.1.13-1",
-          "from": "readable-stream@~1.1.9",
+          "from": "readable-stream@~1.1.13",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0"
+              "from": "core-util-is@~1.0.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
@@ -337,11 +364,13 @@
             },
             "string_decoder": {
               "version": "0.10.25-1",
-              "from": "string_decoder@~0.10.x"
+              "from": "string_decoder@~0.10.x",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1"
+              "from": "inherits@2",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
@@ -353,47 +382,56 @@
       }
     },
     "request": {
-      "version": "2.37.0",
-      "from": "request@2.37.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.37.0.tgz",
+      "version": "2.40.0",
+      "from": "request@2.40.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "0.6.6",
-          "from": "qs@~0.6.0"
+          "version": "1.0.2",
+          "from": "qs@~1.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0"
+          "from": "json-stringify-safe@~5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "mime-types": {
-          "version": "1.0.1",
-          "from": "mime-types@~1.0.1"
+          "version": "1.0.2",
+          "from": "mime-types@~1.0.1",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.0"
+          "from": "forever-agent@~0.5.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@~1.4.0"
+          "from": "node-uuid@~1.4.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
           "from": "tough-cookie@>=0.12.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.0",
-              "from": "punycode@>=0.2.0"
+              "from": "punycode@>=0.2.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz"
             }
           }
         },
         "form-data": {
           "version": "0.1.4",
           "from": "form-data@~0.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.5",
               "from": "combined-stream@~0.0.4",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
@@ -404,21 +442,25 @@
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.11"
+              "from": "mime@~1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@~0.9.0"
+              "from": "async@~0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@~0.4.0"
+          "from": "tunnel-agent@~0.4.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "http-signature": {
           "version": "0.10.0",
           "from": "http-signature@~0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
@@ -439,7 +481,8 @@
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@~0.3.0"
+          "from": "oauth-sign@~0.3.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "hawk": {
           "version": "1.1.1",
@@ -448,25 +491,35 @@
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x"
+              "from": "hoek@0.9.x",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x"
+              "from": "boom@0.4.x",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x"
+              "from": "cryptiles@0.2.x",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x"
+              "from": "sntp@0.2.x",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@~0.5.0"
+          "from": "aws-sign2@~0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.4",
+          "from": "stringstream@~0.0.4",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "outdated": "npm outdated --depth 0"
   },
   "dependencies": {
-    "bluebird": "2.2.1",
+    "bluebird": "2.2.2",
     "convict": "0.4.2",
-    "hapi": "6.2.0",
+    "hapi": "6.4.0",
     "intel": "1.0.0-b4",
-    "joi": "4.6.1",
-    "mysql": "2.3.2",
-    "request": "2.37.0"
+    "joi": "4.6.2",
+    "mysql": "2.4.2",
+    "request": "2.40.0"
   },
   "devDependencies": {
     "awsbox": "~0.7.0",
@@ -28,12 +28,12 @@
     "grunt-jscs": "~0.6.1",
     "grunt-mocha-test": "~0.11.0",
     "grunt-nodemon": "~0.3.0",
-    "grunt-nsp-shrinkwrap": "0.0.3",
+    "grunt-nsp-shrinkwrap": "~0.0.3",
     "insist": "0.x",
     "jshint-stylish": "~0.4.0",
     "load-grunt-tasks": "~0.6.0",
     "mocha-text-cov": "~0.1.0",
-    "nock": "~0.42.1",
+    "nock": "~0.44.0",
     "time-grunt": "~0.4.0"
   },
   "repo": "mozilla/fxa-profile-server",


### PR DESCRIPTION
Updated hapi and request to latest, as well as a few other patch/minor modules.
Everything passes `npm test`, `grunt validate-shrinkwrap`, and `npm outdated`.

Fixes #35
