### PR TITLE
fix(config): use ip addresses instead of localhost

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -62,7 +62,7 @@ const conf = convict({
       default: {
         'gravatar':
             '^http(://www|s://secure)\\.gravatar\\.com/avatar/[0-9a-f]{32}$',
-        'fxa': '^http://localhost:1112/a/[0-9a-f]{32}$'
+        'fxa': '^http://127.0.0.1:1112/a/[0-9a-f]{32}$'
       }
     },
     uploads: {
@@ -93,7 +93,7 @@ const conf = convict({
     },
     url: {
       doc: 'Pattern to generate FxA avatar URLs. {id} will be replaced.',
-      default: 'http://localhost:1112/a/{id}'
+      default: 'http://127.0.0.1:1112/a/{id}'
     }
   },
   logging: {
@@ -178,12 +178,12 @@ const conf = convict({
   publicUrl: {
     format: 'url',
     env: 'PUBLIC_URL',
-    default: 'http://localhost:1111'
+    default: 'http://127.0.0.1:1111'
   },
   server: {
     host: {
       env: 'HOST',
-      default: 'localhost'
+      default: '127.0.0.1'
     },
     port: {
       env: 'PORT',
@@ -194,7 +194,7 @@ const conf = convict({
   worker: {
     host: {
       env: 'WORKER_HOST',
-      default: 'localhost'
+      default: '127.0.0.1'
     },
     port: {
       env: 'WORKER_PORT',
@@ -202,7 +202,7 @@ const conf = convict({
       default: 1113
     },
     url: {
-      default: 'http://localhost:1113'
+      default: 'http://127.0.0.1:1113'
     }
   }
 });

--- a/test/lib/static.js
+++ b/test/lib/static.js
@@ -21,7 +21,7 @@ function opts(options) {
 
 exports.get = function get(options) {
   options = opts(options);
-  options.url = options.url.replace('http://localhost:1112', '');
+  options.url = options.url.replace('http://127.0.0.1:1112', '');
   options.method = 'GET';
   return request(options);
 };


### PR DESCRIPTION
I was getting CORs errors because of a domain mismatch between `127.0.0.1` and `localhost`. Since the other repos are using ip addresses, we can just switch to it here as well.

@seanmonstar r?
