### PR TITLE
store PNG images in S3 as content-type image/png

### DIFF
--- a/lib/compute/image-cc.js
+++ b/lib/compute/image-cc.js
@@ -11,6 +11,7 @@ const P = require('../promise');
 
 const HEIGHT = String(config.get('img.resize.height'));
 const WIDTH = String(config.get('img.resize.width'));
+const CONTENT_TYPE_PNG = 'image/png';
 
 logger.info('Worker starting up %:2j', config.get('img'));
 
@@ -43,7 +44,7 @@ function compute(msg, callback) {
   var src = Buffer(msg.payload);
   processImage(src).then(function(out) {
     logger.debug('Out %d bytes', out.length);
-    return img.upload(id, out);
+    return img.upload(id, out, CONTENT_TYPE_PNG);
   }).done(function() {
     callback({ id: id });
   }, function(err) {

--- a/lib/img/aws.js
+++ b/lib/img/aws.js
@@ -9,6 +9,7 @@ const config = require('../config');
 const logger = require('../logging').getLogger('fxa.img.aws');
 
 const PUBLIC_BUCKET = config.get('img.uploads.dest.public');
+const CONTENT_TYPE_PNG = 'image/png';
 
 if (!/^[a-zA-Z0-9_\-]+$/.test(PUBLIC_BUCKET)) {
   throw new Error('Illegal Bucket Name: ' + PUBLIC_BUCKET);
@@ -25,7 +26,7 @@ AwsDriver.connect = function awsConnect(options) {
 
 AwsDriver.prototype = {
 
-  upload: function awsUpload(key, buf) {
+  upload: function awsUpload(key, buf, contentType) {
     var s3 = this._s3;
     var bucket = PUBLIC_BUCKET;
     return new P(function(resolve, reject) {
@@ -33,7 +34,8 @@ AwsDriver.prototype = {
       s3.putObject({
         Body: buf,
         Bucket: bucket,
-        Key: key
+        Key: key,
+        ContentType: contentType || CONTENT_TYPE_PNG
       }, function(err, data) {
         if (err) {
           reject(err);


### PR DESCRIPTION
This addresses https://github.com/mozilla-services/puppet-config/issues/852 - currently the images are being served back from cloudfront with 'application/octet-stream' which is the default when you upload with aws-sdk without specifying a ContentType parameter.
