### PR TITLE
Added a few fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,12 @@
     "through": "^2.3.4",
     "time-grunt": "^0.4.0"
   },
-  "repo": "mozilla/fxa-profile-server",
+  "repository": "mozilla/fxa-profile-server",
+  "bugs": "https://github.com/mozilla/fxa-profile-server/issues",
+  "homepage": "https://github.com/mozilla/fxa-profile-server",
   "author": "Sean McArthur <sean.monstar@gmail.com>",
-  "license": "MPLv2.0"
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "license": "MPL 2.0"
 }


### PR DESCRIPTION
Changed `repo` to `repository`.
Added `bugs` and `homepage` (even though npm technically resolves them from the `repository` field anyways &mdash; which is probably all moot since `private` is set to true).

Current [package.json validator](http://package-json-validator.com/) output is:

``` json
{
  "valid": false,
  "errors": [
    "Type for field repository, was expected to be object, not string"
  ],
  "warnings": [
    "Missing recommended field: keywords",
    "Missing recommended field: contributors"
  ]
}
```

(The "Type for field repository, was expected to be object, not string" feels like an error in the validator, https://github.com/gorillamania/package.json-validator/issues/29)
