### PR TITLE
fix(logging): remove spaces from logging op name in the worker

### DIFF
--- a/lib/server/worker.js
+++ b/lib/server/worker.js
@@ -44,7 +44,9 @@ exports.create = function() {
         allow: ['image/png', 'image/jpeg']
       },
       handler: function upload(req, reply) {
-        logger.debug('Worker received %d bytes', req.headers['content-length']);
+        logger.debug('worker.receive', {
+          contentLength: req.headers['content-length']
+        });
         compute.image(req.params.id, req.payload).done(reply, reply);
       }
     }


### PR DESCRIPTION
After the switch to mozlog, the first arg to all logging calls is an
"op name" which cannot contain spaces.  This removes one such instance
which was causing (unhandled) errors in the worker process.

Closes #77
