### PR TITLE
fix(logging): remove spaces from logging op name

### DIFF
--- a/bin/_static.js
+++ b/bin/_static.js
@@ -7,7 +7,7 @@ const logger = require('../lib/logging')('bin._static');
 const server = require('../lib/server/_static').create();
 
 if (config.env !== 'dev') {
-  logger.warn('static bin should only be for local dev');
+  logger.warn('sanity-check', 'static bin should only be used for local dev!');
 }
 
 

--- a/lib/img/local.js
+++ b/lib/img/local.js
@@ -19,7 +19,7 @@ if (!fs.existsSync(PUBLIC_DIR)) {
 function LocalDriver() {
   var env = config.get('env');
   if (env !== 'dev' && env !== 'test') {
-    logger.warn('Using img.local driver!');
+    logger.warn('sanity-check', 'using img.local driver with non-dev env!');
   }
 }
 


### PR DESCRIPTION
I found a couple more instances of the bug behind #78, although they're not code-paths executed on dev so they won't be causing us any errors.  Here's a stab a fixing them to be inline with mozlog.
