### PR TITLE
feat(docker): Dockerfile and README update for basic docker development workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:trusty
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs npm
+RUN ln -sf /usr/bin/nodejs /usr/local/bin/node
+
+RUN useradd --home-dir /opt/fxa fxa
+USER fxa
+
+WORKDIR /opt/fxa
+
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -20,10 +20,25 @@ cd fxa-profile-server
 npm install
 ```
 
+## Docker Based Development
+
+To run the profile server via Docker, two steps are required:
+
+    $ docker build --rm -t mozilla/fxa_profile_server
+    $ docker run --rm -v $PWD:/opt/fxa mozilla/fxa_profile_server npm install
+    $ docker run --rm -v $PWD:/opt/fxa --net=host mozilla/fxa_profile_server
+
+This method shares the codebase into the running container so that you can install npm and various modules required by package.json. It then runs profile-server in a container, while allowing you to use your IDE of choice from your normal desktop environment to develop code.
+
 Running tests:
 
 ```
 npm test
+```
+
+To run tests via Docker:
+```
+docker run --rm -v $PWD:/opt/fxa --net=host mozilla/fxa_profile_server npm test
 ```
 
 Running the server locally:


### PR DESCRIPTION
I've added a dockerfile and some instructions to README.md explaining how to use Docker to develop and run the profile server. It allows for development with an IDE underneath a running container as one would normally work. This means changes and running the verifier are mostly transparent to normal development. If there are any questions feel free to ask here or in IRC.