### PR TITLE
feat(avatar): add multiple image support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -136,6 +136,12 @@ Returns details of the current user avatar, or an empty object if none.
 
 An avatar `id` is a 32-length hexstring.
 
+All avatars hosted by Firefox Accounts (see 3rd-party provider docs for
+their equivalent) can be accessed as multiple sizes. The default size is
+200x200 pixels. There is are small (100x100) and large (600x600)
+variants, which can accessed by adding the `_small` or `_large` suffix
+to the avatar URL.
+
 #### Request
 
 ```sh

--- a/lib/config.js
+++ b/lib/config.js
@@ -72,14 +72,6 @@ const conf = convict({
         default: Math.ceil(require('os').cpus().length * 1.25)
       }
     },
-    resize: {
-      height: {
-        default: 600
-      },
-      width: {
-        default: 600
-      }
-    },
     url: {
       doc: 'Pattern to generate FxA avatar URLs. {id} will be replaced.',
       default: 'http://127.0.0.1:1112/a/{id}'

--- a/lib/img/index.js
+++ b/lib/img/index.js
@@ -11,6 +11,12 @@ const logger = require('../logging')('img');
 const klass = config.get('img.driver') === 'aws' ?
   require('./aws') : require('./local');
 
+exports.SIZES = Object.seal({
+  small: { w: 100, h: 100 },
+  default: { w: 200, h: 200 },
+  large: { w: 600, h: 600 }
+});
+
 function unique() {
   return crypto.randomBytes(16).toString('hex');
 }


### PR DESCRIPTION
When an avatar is uploaded, we will now generate multiple sizes of the
image, to better accommodate various environments that the avatar may
appear.

The sizes generated are based of current constants in the `lib/img/index.js`
module. The `SIZES` constant contains a map of `suffix` to `height/width`
values. The suffix `default` is special cased, and will actually mean no
suffix. Every other value will be appended on the end of the URL, with an
underscore.

The current `SIZES` are:

    {
      small: { h: 100, w: 100 },
      default: { h: 200, w: 200 },
      large: { h 600, w: 600 }
    }

which generate 3 images when an upload occurs:

- https://s3.url/<imageid>_small (100px x 100px)
- https://s3.url/<imageid> (200px x 200px)
- https://s3.url/<imageid>_large (600px x 600px)

Closes #68
Closes #89