### PR TITLE
fix(docs): note "avatar" field in /v1/profile response

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -80,7 +80,8 @@ curl -v \
 ```js
 {
   "uid": "6d940dd41e636cc156074109b8092f96",
-  "email": "user@example.domain"
+  "email": "user@example.domain",
+  "avatar": "https://secure.gravatar.com/avatar/6d940dd41e636cc156074109b8092f96"
 }
 ```
 


### PR DESCRIPTION
I noticed while working on https://github.com/mozilla/PyFxA/pull/15 that the `/v1/profile` endpoint returns an "avatar" field, but this isn't shown in the example in docs.