### PR TITLE
chore(travis): also build/test on iojs and nodejs 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language: node_js
 
 node_js:
   - '0.10'
+  - '0.12'
+  - iojs
 
 notifications:
   email:
     smcarthur@mozilla.com
+    jrgm@mozilla.com
   irc:
     channels:
       - 'irc.mozilla.org#fxa'


### PR DESCRIPTION
This adds `'iojs` and `nodejs 0.12` to the travis runs. I don't expect we'll be moving from `0.10` soon, but since they currently pass, we should probably lock that in, and if we have failures that are due to upstream, we can feed that information back to the respective upstream repositories. 

This is kind of a meta-PR to see if folks agree there is value in doing this at this point. It does add some overhead to tests, and possible flakiness, but I think as {node,io}.js users we should do this.