### PR TITLE
feat(profile): return all /profile pieces that scopes allow

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const logger = require('./logging')('batch');
+const P = require('./promise');
+
+function inject(server, options) {
+  return new P(function(resolve) {
+    server.inject(options, resolve);
+  });
+}
+
+// called in a route as `batch(req, map)`, where map is an Object
+// mapping property names to routes.
+//
+// Ex: batch(req, { email: '/v1/email', avatar: '/v1/avatar' }).done(reply)
+//
+// The above will fetch both routes as GET requests, into `emailRes` and
+// `avatarRes`. The end result of the returned promise would then be:
+//
+// { email: emailRes['email'], avatar: avatarRes['avatar'] }
+function batch(request, map) {
+  var result = {};
+  Object.keys(map).forEach(function(prop) {
+    var url = map[prop];
+    result[prop] = inject(request.server, {
+      method: 'get',
+      url: url,
+      headers: request.headers,
+      credentials: request.auth.credentials
+    }).then(function(res) {
+      switch (res.statusCode) {
+        case 200:
+          return res.result[prop];
+        case 403:
+        case 404:
+          logger.debug('batch.' + res.statusCode, {
+            scope: request.auth.credentials.scope,
+            response: res.result
+          });
+          return undefined;
+        default:
+          throw res.result;
+      }
+    });
+  });
+  return P.props(result).then(function(result) {
+    Object.keys(result).forEach(function(key) {
+      if (result[key] === undefined) {
+        delete result[key];
+      }
+    });
+    return result;
+  });
+}
+
+module.exports = batch;

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -24,20 +24,24 @@ function loadProviders() {
   }));
 }
 
+var driverPromise;
 var driver;
 function withDriver() {
   if (driver) {
     return P.resolve(driver);
   }
-  var p;
-  if (config.get('db.driver') === 'mysql') {
-    p = klass.connect(config.get('mysql'));
-  } else {
-    p = klass.connect();
+  if (driverPromise) {
+    return driverPromise;
   }
-  return p.then(function(store) {
+  if (config.get('db.driver') === 'mysql') {
+    driverPromise = klass.connect(config.get('mysql'));
+  } else {
+    driverPromise = klass.connect();
+  }
+  return driverPromise.then(function(store) {
     logger.debug('connected', config.get('db.driver'));
     driver = store;
+    driverPromise = null;
   }).then(loadProviders).then(function() {
     return driver;
   });

--- a/test/api.js
+++ b/test/api.js
@@ -115,11 +115,29 @@ describe('/profile', function() {
     });
   });
 
-  it('should NOT return a profile if wrong scope', function() {
+  it('should return filtered profile if smaller scope', function() {
     mock.token({
       user: USERID,
       email: 'user@example.domain',
       scope: ['profile:email']
+    });
+    return Server.api.get({
+      url: '/profile',
+      headers: {
+        authorization: 'Bearer ' + tok
+      }
+    }).then(function(res) {
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.result.email, 'user@example.domain');
+      assert.equal(Object.keys(res.result).length, 1);
+    });
+  });
+
+  it('should require a profile:* scope', function() {
+    mock.token({
+      user: USERID,
+      email: 'user@example.domain',
+      scope: ['some:other:scope']
     });
     return Server.api.get({
       url: '/profile',
@@ -181,7 +199,7 @@ describe('/uid', function() {
     });
   });
 
-  it('should NOT return a profile if wrong scope', function() {
+  it('should NOT return a uid if wrong scope', function() {
     mock.token({
       user: USERID,
       email: 'user@example.domain',
@@ -537,7 +555,6 @@ describe('/display_name', function() {
           authorization: 'Bearer ' + tok
         }
       }).then(function(res) {
-        console.log('res', res);
         assert.equal(res.statusCode, 404);
       });
     });


### PR DESCRIPTION
So basically, using Hapi's `server.inject()`, the `/profile` endpoint just clumps together the results of requests to each lesser piece of information. Any 403s (scope not allowed) and 404s (such as has no avatar) simply means that value isn't in the returned result.

Closes #108 

