### PR TITLE
feat(avatar): Add etag to the profile avatar API endpoint

### DIFF
--- a/lib/routes/avatar/get.js
+++ b/lib/routes/avatar/get.js
@@ -35,7 +35,13 @@ module.exports = {
   handler: function avatar(req, reply) {
     db.getSelectedAvatar(req.auth.credentials.user)
       .then(avatarOrEmpty)
-      .done(reply, reply);
+      .done(function (result) {
+        var rep = reply(result);
+        if (result.id) {
+          rep = rep.etag(result.id);
+        }
+        return rep;
+      }, reply);
   }
 };
 

--- a/test/api.js
+++ b/test/api.js
@@ -253,6 +253,26 @@ describe('/avatar', function() {
         assert.equal(res.result.id, id2);
       });
     });
+    it('should include an etag in the http response', function() {
+      mock.token({
+        user: user,
+        email: 'user@example.domain',
+        scope: ['profile:avatar']
+      });
+      return Server.api.get({
+        url: '/avatar',
+        headers: {
+          authorization: 'Bearer ' + tok
+        }
+      }).then(function(res) {
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.result.avatar, GRAVATAR);
+        assert.equal(res.result.id, id2);
+
+        var etag = res.headers.etag.substr(1, 32);
+        assert.equal(etag, id2);
+      });
+    });
   });
 
   describe('POST', function() {


### PR DESCRIPTION
Related to #111. We still have to figure out how to use these etags.