### PR TITLE
chore(travis): use npm@2 for more stable installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
   - NODE_ENV=test DB=mysql IMG=aws
 
 before_install:
+  - npm install -g npm@2
+  - npm config set spin false
   - sudo apt-get install graphicsmagick
   - "mysql -e 'DROP DATABASE IF EXISTS fxa_profile;'"
   - "mysql -e 'CREATE DATABASE fxa_profile;'"


### PR DESCRIPTION
We should use npm@2 since the default with nodejs 0.10 is an obsolete and flaky version of npm (1.4.28). We already build production with npm@2.6.1; I'm not particularly concerned with what version travis uses as long as it in the 2.x series.

r? - @seanmonstar - note no need to merge this before train-42 is cut.