### PR TITLE
fix(config): add options events.region and events.queueUrl

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -28,6 +28,18 @@ const conf = convict({
     format: ['dev', 'test', 'stage', 'prod'],
     default: 'dev'
   },
+  events: {
+    region: {
+      doc: 'AWS Region of fxa account events',
+      format: String,
+      default: ''
+    },
+    queueUrl: {
+      doc: 'SQS queue url for fxa account events',
+      format: String,
+      default: ''
+    }
+  },
   git: {
     commit: {
       doc: 'Commit SHA when in stage/production',


### PR DESCRIPTION
I assume you meant to add these options. Merging when travis passes because latest.dev.lcip.org is currently broken.