### PR TITLE
fix(display_name): Don't allow control characters in the display_name field

### DIFF
--- a/lib/routes/display_name/post.js
+++ b/lib/routes/display_name/post.js
@@ -7,6 +7,20 @@ const db = require('../../db');
 
 const EMPTY = Object.create(null);
 
+// We're pretty liberal with what's allowed in a display-name,
+// but we exclude the following classes of characters:
+//
+//   \u0000-\u001F  - C0 (ascii) control characters
+//   \u007F         - ascii DEL character
+//   \u0080-\u009F  - C1 (ansi escape) control characters
+//   \u2028-\u2029  - unicode line/paragraph separator
+//   \uE000-\uF8FF  - BMP private use area
+//   \uFFF9-\uFFFF  - unicode "specials" block
+//
+// We might tweak this list in future.
+
+const ALLOWED_DISPLAY_NAME_CHARS = /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uE000-\uF8FF\uFFF9-\uFFFF])*$/;
+
 module.exports = {
   auth: {
     strategy: 'oauth',
@@ -14,7 +28,7 @@ module.exports = {
   },
   validate: {
     payload: {
-      displayName: Joi.string().required().allow('')
+      displayName: Joi.string().required().allow('').regex(ALLOWED_DISPLAY_NAME_CHARS)
     }
   },
   handler: function avatarPost(req, reply) {


### PR DESCRIPTION
Fixes #126.

I went with a very slim list of control characters that IMHO have no business being in a display name, and would only be there to cause trouble.  I also added tests that various other unicodey things are accepted without trouble, which seemed to work except for one issue with JSON.parse-ing the result payload in the tests.

@seanmonstar r?