### PR TITLE
chore(version): add /__version__ route with source repo

### DIFF
--- a/lib/routing.js
+++ b/lib/routing.js
@@ -16,6 +16,11 @@ module.exports = [
   },
   {
     method: 'GET',
+    path: '/__version__',
+    config: require('./routes/root')
+  },
+  {
+    method: 'GET',
     path: '/__heartbeat__',
     config: require('./routes/heartbeat')
   },

--- a/test/server.js
+++ b/test/server.js
@@ -9,9 +9,8 @@ const Server = require('./lib/server');
 /*global describe,it*/
 
 describe('server', function() {
-
-  describe('/', function() {
-    it('should return the version', function() {
+  function checkVersionAndHeaders(path) {
+    return function(done) {
       return Server.get('/').then(function(res) {
         assert.equal(res.statusCode, 200);
         assert.equal(res.result.version, require('../package.json').version);
@@ -28,11 +27,20 @@ describe('server', function() {
           'x-frame-options': 1,
           'x-xss-protection': 1
         };
+
         Object.keys(res.headers).forEach(function(header) {
           assert.ok(!other[header.toLowerCase()]);
         });
-      });
-    });
+      }).done(done, done);
+    };
+  }
+
+  describe('/', function() {
+    it('should return the version', checkVersionAndHeaders('/'));
+  });
+
+  describe('/__version__', function() {
+    it('should return the version', checkVersionAndHeaders('/__version__'));
   });
 
   describe('/__heartbeat__', function() {


### PR DESCRIPTION
Fixes #134. This preserves the `/` route but extends the output to include the git source repo, and adds an alternate route `/__version__` that serves the same content and a couple of more tests of the output. 

So content used to look like
```
{
  "version": "0.44.0",
  "commit": "e31f764c6dcfaeecc8e0ac531002eeab279137ea"
}
```
and is now like:
```
{
  "version": "0.44.0",
  "commit": "e31f764c6dcfaeecc8e0ac531002eeab279137ea",
  "source": "git://github.com/mozilla/fxa-profile-server.git"
}
```