### PR TITLE
fix(version): use explicit path with git-config

### DIFF
--- a/lib/routes/root.js
+++ b/lib/routes/root.js
@@ -12,13 +12,13 @@ const version = require('../../package.json').version;
 var commitHash, source;
 
 // See if config/version.json exists (part of rpm builds)
-(function() {
-  try {
-    var info = require('../../config/version.json');
-    commitHash = info.version.hash;
-    source = info.version.source;
-  } catch(e) { /* ignore */ }
-})();
+try {
+  var info = require('../../config/version.json');
+  commitHash = info.version.hash;
+  source = info.version.source;
+} catch(e) {
+  /* ignore */
+}
 
 module.exports = {
   response: {
@@ -34,7 +34,7 @@ module.exports = {
         version: version,
         commit: commitHash,
         source: source
-      }).spaces(2);
+      }).spaces(2).suffix('\n');
     }
 
     if (commitHash) {
@@ -46,7 +46,9 @@ module.exports = {
     var cmd = util.format('git --git-dir=%s rev-parse HEAD', gitDir);
     exec(cmd, function(err, stdout) { // eslint-disable-line handle-callback-err
       commitHash = stdout.replace(/\s+/, '');
-      exec('git config --get remote.origin.url', function(err, stdout) { // eslint-disable-line handle-callback-err
+      var configPath = path.join(gitDir, 'config');
+      var cmd = util.format('git config --file %s --get remote.origin.url', configPath);
+      exec(cmd, function(err, stdout) { // eslint-disable-line handle-callback-err
         source = stdout.replace(/\s+/, '');
         return sendReply();
       });


### PR DESCRIPTION
Apologies for futzing with this. 

I realized that git-config should use an explicit path to the config location (because, on fxa-dev boxes, fxa-oauth-server starts from `/`, not the checked out repo, and so can't find the config). 

Also, eliminated and unused IFFE, and added a newline to the output because nicer.