### PR TITLE
feat(email): fetch email from auth-server /account/profile

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,14 @@ const conf = convict({
       default: 1
     }
   },
+  authServer: {
+    url: {
+      doc: 'URL of fxa-auth-server',
+      env: 'AUTH_SERVER_URL',
+      format: 'url',
+      default: 'http://127.0.0.1:9000/v1'
+    }
+  },
   db: {
     driver: {
       env: 'DB',

--- a/lib/error.js
+++ b/lib/error.js
@@ -138,5 +138,16 @@ AppError.oauthError = function oauthError(err) {
   });
 };
 
+AppError.authError = function authError(err) {
+  return new AppError({
+    code: 503,
+    error: 'Service Unavailable',
+    errno: 105,
+    message: 'Auth server error'
+  }, {
+    cause: err
+  });
+};
+
 module.exports = AppError;
 

--- a/lib/routes/email.js
+++ b/lib/routes/email.js
@@ -5,6 +5,11 @@
 const Joi = require('joi');
 
 const AppError = require('../error');
+const config = require('../config');
+const logger = require('../logging')('routes.email');
+const request = require('../request');
+
+const AUTH_SERVER_URL = config.get('authServer.url') + '/account/profile';
 
 module.exports = {
   auth: {
@@ -17,14 +22,30 @@ module.exports = {
     }
   },
   handler: function email(req, reply) {
-    var email = req.auth.credentials.email;
-    if (email) {
+    request.get(AUTH_SERVER_URL, {
+      headers: {
+        Authorization: 'Bearer ' + req.auth.credentials.token
+      },
+      json: true
+    }, function(err, res, body) {
+      if (err) {
+        logger.error('request.auth_server.network', err);
+        return reply(new AppError.authError('network error'));
+      }
+      if (res.statusCode >= 400) {
+        logger.error('request.auth_server.fail', { code: res.statusCode });
+        return reply(new AppError.authError('auth server error'));
+      }
+
+      if (!body || !body.email) {
+        return reply(
+          new AppError.authError('email field missing from auth response')
+        );
+      }
       reply({
-        email: email
+        email: body.email
       });
-    } else {
-      reply(new AppError.oauthError('email field missing from oauth response'));
-    }
+    });
   }
 };
 

--- a/lib/server/web.js
+++ b/lib/server/web.js
@@ -54,11 +54,13 @@ exports.create = function createServer() {
         request.post({
           url: url,
           json: {
-            token: token
+            token: token,
+            email: false // disables email fetching of oauth server
           }
         }, function(err, resp, body) {
           if (err || resp.statusCode >= 500) {
             err = err || resp.statusMessage || 'unknown';
+            logger.error('oauth.error', err);
             return reply(AppError.oauthError(err));
           }
           if (body.code >= 400) {
@@ -66,6 +68,8 @@ exports.create = function createServer() {
             return reply(AppError.unauthorized(body.message));
           }
           logger.debug('auth.valid', body);
+          // Include the raw token, so we can use it in sub-requests
+          body.token = token
           reply(null, {
             credentials: body
           });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -123,30 +123,30 @@
               "from": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
               "dependencies": {
-                "JSV": {
-                  "version": "4.0.2",
-                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
-                },
                 "nomnom": {
                   "version": "1.8.1",
                   "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
                   "dependencies": {
+                    "underscore": {
+                      "version": "1.6.0",
+                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                    },
                     "chalk": {
                       "version": "0.4.0",
                       "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
                       "dependencies": {
-                        "ansi-styles": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-                        },
                         "has-color": {
                           "version": "0.1.7",
                           "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
                           "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                        },
+                        "ansi-styles": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                         },
                         "strip-ansi": {
                           "version": "0.1.1",
@@ -154,13 +154,13 @@
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                         }
                       }
-                    },
-                    "underscore": {
-                      "version": "1.6.0",
-                      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                     }
                   }
+                },
+                "JSV": {
+                  "version": "4.0.2",
+                  "from": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz"
                 }
               }
             }
@@ -181,15 +181,15 @@
           "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
-            "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            },
             "wordwrap": {
               "version": "0.0.3",
               "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
@@ -234,20 +234,20 @@
       "from": "https://registry.npmjs.org/gm/-/gm-1.17.0.tgz",
       "resolved": "https://registry.npmjs.org/gm/-/gm-1.17.0.tgz",
       "dependencies": {
-        "array-parallel": {
-          "version": "0.1.3",
-          "from": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz"
+        "debug": {
+          "version": "0.7.0",
+          "from": "debug@0.7.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.0.tgz"
         },
         "array-series": {
           "version": "0.1.5",
           "from": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/array-series/-/array-series-0.1.5.tgz"
         },
-        "debug": {
-          "version": "0.7.0",
-          "from": "debug@0.7.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.0.tgz"
+        "array-parallel": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/array-parallel/-/array-parallel-0.1.3.tgz"
         }
       }
     },
@@ -280,11 +280,6 @@
           "version": "0.4.14",
           "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
-        },
-        "exit": {
-          "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
@@ -327,11 +322,6 @@
             }
           }
         },
-        "getobject": {
-          "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
-        },
         "glob": {
           "version": "3.1.21",
           "from": "glob@>=3.1.21 <3.2.0",
@@ -349,33 +339,6 @@
             }
           }
         },
-        "grunt-legacy-log": {
-          "version": "0.1.2",
-          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
-          "dependencies": {
-            "grunt-legacy-log-utils": {
-              "version": "0.1.1",
-              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
-            },
-            "lodash": {
-              "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-            },
-            "underscore.string": {
-              "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-            }
-          }
-        },
-        "grunt-legacy-util": {
-          "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
-        },
         "hooker": {
           "version": "0.2.3",
           "from": "hooker@>=0.2.3 <0.3.0",
@@ -385,40 +348,6 @@
           "version": "0.2.11",
           "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
-        },
-        "js-yaml": {
-          "version": "2.0.5",
-          "from": "js-yaml@>=2.0.5 <2.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-          "dependencies": {
-            "argparse": {
-              "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-              "dependencies": {
-                "underscore": {
-                  "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
-                },
-                "underscore.string": {
-                  "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
-                }
-              }
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
@@ -454,6 +383,11 @@
           "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+        },
         "underscore.string": {
           "version": "2.2.1",
           "from": "underscore.string@>=2.2.1 <2.3.0",
@@ -463,6 +397,72 @@
           "version": "1.0.9",
           "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.2",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
         }
       }
     },
@@ -471,6 +471,18 @@
       "from": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        },
         "findup-sync": {
           "version": "0.1.3",
           "from": "findup-sync@0.1.3",
@@ -512,18 +524,6 @@
             }
           }
         },
-        "nopt": {
-          "version": "1.0.10",
-          "from": "nopt@1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.5",
-              "from": "abbrev@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-            }
-          }
-        },
         "resolve": {
           "version": "0.3.1",
           "from": "resolve@0.3.1",
@@ -541,48 +541,6 @@
           "from": "conventional-changelog@0.0.6",
           "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-0.0.6.tgz",
           "dependencies": {
-            "event-stream": {
-              "version": "3.1.7",
-              "from": "event-stream@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
-              "dependencies": {
-                "duplexer": {
-                  "version": "0.1.1",
-                  "from": "duplexer@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-                },
-                "from": {
-                  "version": "0.1.3",
-                  "from": "from@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
-                },
-                "map-stream": {
-                  "version": "0.1.0",
-                  "from": "map-stream@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-                },
-                "pause-stream": {
-                  "version": "0.0.11",
-                  "from": "pause-stream@0.0.11",
-                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
-                },
-                "split": {
-                  "version": "0.2.10",
-                  "from": "split@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
-                },
-                "stream-combiner": {
-                  "version": "0.0.4",
-                  "from": "stream-combiner@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-                },
-                "through": {
-                  "version": "2.3.6",
-                  "from": "through@>=2.3.1 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-                }
-              }
-            },
             "lodash.assign": {
               "version": "2.4.1",
               "from": "lodash.assign@>=2.4.1 <2.5.0",
@@ -593,23 +551,6 @@
                   "from": "lodash._basecreatecallback@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
                   "dependencies": {
-                    "lodash._setbinddata": {
-                      "version": "2.4.1",
-                      "from": "lodash._setbinddata@>=2.4.1 <2.5.0",
-                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-                      "dependencies": {
-                        "lodash._isnative": {
-                          "version": "2.4.1",
-                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
-                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-                        },
-                        "lodash.noop": {
-                          "version": "2.4.1",
-                          "from": "lodash.noop@>=2.4.1 <2.5.0",
-                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-                        }
-                      }
-                    },
                     "lodash.bind": {
                       "version": "2.4.1",
                       "from": "lodash.bind@>=2.4.1 <2.5.0",
@@ -697,6 +638,23 @@
                       "from": "lodash.identity@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
                     },
+                    "lodash._setbinddata": {
+                      "version": "2.4.1",
+                      "from": "lodash._setbinddata@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash.noop": {
+                          "version": "2.4.1",
+                          "from": "lodash.noop@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                        }
+                      }
+                    },
                     "lodash.support": {
                       "version": "2.4.1",
                       "from": "lodash.support@>=2.4.1 <2.5.0",
@@ -711,11 +669,6 @@
                     }
                   }
                 },
-                "lodash._objecttypes": {
-                  "version": "2.4.1",
-                  "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
-                },
                 "lodash.keys": {
                   "version": "2.4.1",
                   "from": "lodash.keys@>=2.4.1 <2.5.0",
@@ -726,17 +679,64 @@
                       "from": "lodash._isnative@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
-                    "lodash._shimkeys": {
-                      "version": "2.4.1",
-                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
-                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-                    },
                     "lodash.isobject": {
                       "version": "2.4.1",
                       "from": "lodash.isobject@>=2.4.1 <2.5.0",
                       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
                     }
                   }
+                },
+                "lodash._objecttypes": {
+                  "version": "2.4.1",
+                  "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                }
+              }
+            },
+            "event-stream": {
+              "version": "3.1.7",
+              "from": "event-stream@>=3.1.0 <3.2.0",
+              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
+              "dependencies": {
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                },
+                "duplexer": {
+                  "version": "0.1.1",
+                  "from": "duplexer@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                },
+                "from": {
+                  "version": "0.1.3",
+                  "from": "from@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+                },
+                "map-stream": {
+                  "version": "0.1.0",
+                  "from": "map-stream@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+                },
+                "pause-stream": {
+                  "version": "0.0.11",
+                  "from": "pause-stream@0.0.11",
+                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+                },
+                "split": {
+                  "version": "0.2.10",
+                  "from": "split@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+                },
+                "stream-combiner": {
+                  "version": "0.0.4",
+                  "from": "stream-combiner@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
             }
@@ -820,6 +820,11 @@
                   "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
                 "readable-stream": {
                   "version": "2.0.0",
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.0.tgz",
@@ -830,15 +835,15 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
                     "process-nextick-args": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -851,11 +856,6 @@
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             },
@@ -1154,35 +1154,35 @@
               "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
                 "deep-is": {
                   "version": "0.1.3",
                   "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
-                "fast-levenshtein": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
-                },
-                "levn": {
-                  "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
-                },
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
                   "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                 }
               }
             },
@@ -1306,16 +1306,21 @@
               "from": "strip-json-comments@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
-            "supports-color": {
-              "version": "1.1.0",
-              "from": "supports-color@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.1.0.tgz"
-            },
             "vow-fs": {
               "version": "0.3.4",
               "from": "vow-fs@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "from": "node-uuid@>=1.4.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
+                "vow-queue": {
+                  "version": "0.4.1",
+                  "from": "vow-queue@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
+                },
                 "glob": {
                   "version": "4.3.5",
                   "from": "glob@>=4.3.1 <5.0.0",
@@ -1375,16 +1380,6 @@
                       }
                     }
                   }
-                },
-                "node-uuid": {
-                  "version": "1.4.2",
-                  "from": "node-uuid@>=1.4.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
-                },
-                "vow-queue": {
-                  "version": "0.4.1",
-                  "from": "vow-queue@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
                 }
               }
             },
@@ -1399,6 +1394,11 @@
                   "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
                 }
               }
+            },
+            "supports-color": {
+              "version": "1.1.0",
+              "from": "supports-color@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.1.0.tgz"
             }
           }
         },
@@ -1423,611 +1423,6 @@
           "version": "0.2.3",
           "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        }
-      }
-    },
-    "grunt-nsp": {
-      "version": "2.1.2",
-      "from": "grunt-nsp@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-nsp/-/grunt-nsp-2.1.2.tgz",
-      "dependencies": {
-        "d": {
-          "version": "0.1.1",
-          "from": "d@0.1.1",
-          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-        },
-        "es5-ext": {
-          "version": "0.10.8",
-          "from": "es5-ext@0.10.8",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
-        },
-        "es6-iterator": {
-          "version": "2.0.0",
-          "from": "es6-iterator@2.0.0",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-        },
-        "es6-symbol": {
-          "version": "3.0.1",
-          "from": "es6-symbol@3.0.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
-        },
-        "nsp": {
-          "version": "2.0.1",
-          "from": "nsp@2.0.1",
-          "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.0.1.tgz",
-          "dependencies": {
-            "agent-base": {
-              "version": "2.0.1",
-              "from": "agent-base@2.0.1",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz"
-            },
-            "ansi": {
-              "version": "0.3.0",
-              "from": "ansi@0.3.0",
-              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "from": "ansi-regex@2.0.0"
-            },
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@2.1.0"
-            },
-            "are-we-there-yet": {
-              "version": "1.0.4",
-              "from": "are-we-there-yet@1.0.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                }
-              }
-            },
-            "asn1": {
-              "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-            },
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "assert-plus@0.1.5",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "async": {
-              "version": "1.5.0",
-              "from": "async@1.5.0"
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "balanced-match": {
-              "version": "0.2.1",
-              "from": "balanced-match@0.2.1"
-            },
-            "bl": {
-              "version": "1.0.0",
-              "from": "bl@1.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
-            },
-            "boom": {
-              "version": "2.10.1",
-              "from": "boom@2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-            },
-            "brace-expansion": {
-              "version": "1.1.1",
-              "from": "brace-expansion@1.1.1"
-            },
-            "builtin-modules": {
-              "version": "1.1.0",
-              "from": "builtin-modules@1.1.0",
-              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "from": "caseless@0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-            },
-            "chalk": {
-              "version": "1.1.1",
-              "from": "chalk@1.1.1"
-            },
-            "chownr": {
-              "version": "0.0.2",
-              "from": "chownr@0.0.2",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz"
-            },
-            "cli-table": {
-              "version": "0.3.1",
-              "from": "cli-table@0.3.1",
-              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
-            },
-            "cliclopts": {
-              "version": "1.1.1",
-              "from": "cliclopts@1.1.1",
-              "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz"
-            },
-            "colors": {
-              "version": "1.0.3",
-              "from": "colors@1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-            },
-            "commander": {
-              "version": "2.9.0",
-              "from": "commander@2.9.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "from": "concat-map@0.0.1"
-            },
-            "concat-stream": {
-              "version": "1.5.1",
-              "from": "concat-stream@1.5.1"
-            },
-            "core-util-is": {
-              "version": "1.0.1",
-              "from": "core-util-is@1.0.1"
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "ctype": {
-              "version": "0.5.3",
-              "from": "ctype@0.5.3",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@2.2.0"
-            },
-            "deep-extend": {
-              "version": "0.2.11",
-              "from": "deep-extend@0.2.11",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "from": "delayed-stream@1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-            },
-            "delegates": {
-              "version": "0.1.0",
-              "from": "delegates@0.1.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@1.0.3"
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "from": "form-data@1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-            },
-            "gauge": {
-              "version": "1.2.2",
-              "from": "gauge@1.2.2",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-            },
-            "generate-function": {
-              "version": "2.0.0",
-              "from": "generate-function@2.0.0"
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "from": "generate-object-property@1.2.0"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@5.0.15"
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "graceful-fs@3.0.8",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@1.0.1",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-            },
-            "har-validator": {
-              "version": "2.0.2",
-              "from": "har-validator@2.0.2",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@2.0.0"
-            },
-            "has-unicode": {
-              "version": "1.0.1",
-              "from": "has-unicode@1.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-            },
-            "hawk": {
-              "version": "3.1.0",
-              "from": "hawk@3.1.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "from": "hoek@2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            },
-            "hosted-git-info": {
-              "version": "2.1.4",
-              "from": "hosted-git-info@2.1.4",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "from": "http-signature@0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
-            },
-            "https-proxy-agent": {
-              "version": "1.0.0",
-              "from": "https-proxy-agent@1.0.0",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
-            },
-            "inflight": {
-              "version": "1.0.4",
-              "from": "inflight@1.0.4"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@2.0.1"
-            },
-            "ini": {
-              "version": "1.3.4",
-              "from": "ini@1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-            },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "from": "is-builtin-module@1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
-            },
-            "is-my-json-valid": {
-              "version": "2.12.2",
-              "from": "is-my-json-valid@2.12.2"
-            },
-            "is-property": {
-              "version": "1.0.2",
-              "from": "is-property@1.0.2"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1"
-            },
-            "isemail": {
-              "version": "1.2.0",
-              "from": "isemail@1.2.0",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "joi": {
-              "version": "6.10.0",
-              "from": "joi@6.10.0",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.0.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "jsonpointer": {
-              "version": "2.0.0",
-              "from": "jsonpointer@2.0.0"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "from": "lodash._basetostring@3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-            },
-            "lodash._createpadding": {
-              "version": "3.6.1",
-              "from": "lodash._createpadding@3.6.1",
-              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-            },
-            "lodash.pad": {
-              "version": "3.1.1",
-              "from": "lodash.pad@3.1.1",
-              "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-            },
-            "lodash.padleft": {
-              "version": "3.1.1",
-              "from": "lodash.padleft@3.1.1",
-              "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-            },
-            "lodash.padright": {
-              "version": "3.1.1",
-              "from": "lodash.padright@3.1.1",
-              "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-            },
-            "lodash.repeat": {
-              "version": "3.0.1",
-              "from": "lodash.repeat@3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-            },
-            "mime-db": {
-              "version": "1.19.0",
-              "from": "mime-db@1.19.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "from": "mime-types@2.1.7",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@0.5.1"
-            },
-            "moment": {
-              "version": "2.10.6",
-              "from": "moment@2.10.6",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
-            },
-            "ms": {
-              "version": "0.7.1",
-              "from": "ms@0.7.1"
-            },
-            "node-uuid": {
-              "version": "1.4.3",
-              "from": "node-uuid@1.4.3",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-            },
-            "nodesecurity-npm-utils": {
-              "version": "3.0.0",
-              "from": "nodesecurity-npm-utils@3.0.0",
-              "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-3.0.0.tgz"
-            },
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "from": "normalize-package-data@2.3.5",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
-            },
-            "npm-package-arg": {
-              "version": "4.0.2",
-              "from": "npm-package-arg@4.0.2",
-              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.2.tgz"
-            },
-            "npm-registry-client": {
-              "version": "6.3.3",
-              "from": "npm-registry-client@6.3.3",
-              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
-              "dependencies": {
-                "semver": {
-                  "version": "4.3.6",
-                  "from": "semver@4.3.6",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-                }
-              }
-            },
-            "npmlog": {
-              "version": "1.2.1",
-              "from": "npmlog@1.2.1",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "oauth-sign@0.8.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "once": {
-              "version": "1.3.2",
-              "from": "once@1.3.2"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@1.0.0"
-            },
-            "pinkie": {
-              "version": "1.0.0",
-              "from": "pinkie@1.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-            },
-            "pinkie-promise": {
-              "version": "1.0.0",
-              "from": "pinkie-promise@1.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.3",
-              "from": "process-nextick-args@1.0.3",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "qs@5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-            },
-            "rc": {
-              "version": "1.1.2",
-              "from": "rc@1.1.2",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.0.4",
-              "from": "readable-stream@2.0.4",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
-            },
-            "request": {
-              "version": "2.65.0",
-              "from": "request@2.65.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
-            },
-            "retry": {
-              "version": "0.6.1",
-              "from": "retry@0.6.1",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
-            },
-            "rimraf": {
-              "version": "2.4.3",
-              "from": "rimraf@2.4.3"
-            },
-            "semver": {
-              "version": "5.0.3",
-              "from": "semver@5.0.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-            },
-            "silent-npm-registry-client": {
-              "version": "1.0.0",
-              "from": "silent-npm-registry-client@1.0.0",
-              "resolved": "https://registry.npmjs.org/silent-npm-registry-client/-/silent-npm-registry-client-1.0.0.tgz"
-            },
-            "slide": {
-              "version": "1.1.6",
-              "from": "slide@1.1.6",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            },
-            "spdx-correct": {
-              "version": "1.0.2",
-              "from": "spdx-correct@1.0.2",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-            },
-            "spdx-exceptions": {
-              "version": "1.0.3",
-              "from": "spdx-exceptions@1.0.3",
-              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.3.tgz"
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.0",
-              "from": "spdx-expression-parse@1.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz"
-            },
-            "spdx-license-ids": {
-              "version": "1.1.0",
-              "from": "spdx-license-ids@1.1.0",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@0.10.31"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@3.0.0"
-            },
-            "strip-json-comments": {
-              "version": "0.1.3",
-              "from": "strip-json-comments@0.1.3",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-            },
-            "subcommand": {
-              "version": "2.0.3",
-              "from": "subcommand@2.0.3",
-              "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.0.3.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@2.0.0"
-            },
-            "topo": {
-              "version": "1.1.0",
-              "from": "topo@1.1.0",
-              "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.0",
-              "from": "tough-cookie@2.2.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "tunnel-agent@0.4.1",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "typedarray@0.0.6"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "from": "util-deprecate@1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "from": "validate-npm-package-license@3.0.1",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-            },
-            "wrappy": {
-              "version": "1.0.1",
-              "from": "wrappy@1.0.1"
-            },
-            "wreck": {
-              "version": "6.3.0",
-              "from": "wreck@6.3.0",
-              "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz"
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
         }
       }
     },
@@ -2066,11 +1461,6 @@
           "from": "cryptiles@2.0.4",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
         },
-        "glue": {
-          "version": "1.0.0",
-          "from": "glue@1.0.0",
-          "resolved": "https://registry.npmjs.org/glue/-/glue-1.0.0.tgz"
-        },
         "h2o2": {
           "version": "2.0.1",
           "from": "h2o2@2.0.1",
@@ -2085,6 +1475,11 @@
           "version": "2.9.0",
           "from": "hoek@2.9.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.9.0.tgz"
+        },
+        "glue": {
+          "version": "1.0.0",
+          "from": "glue@1.0.0",
+          "resolved": "https://registry.npmjs.org/glue/-/glue-1.0.0.tgz"
         },
         "inert": {
           "version": "1.1.1",
@@ -2232,15 +1627,15 @@
           "from": "hoek@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
         },
-        "isemail": {
-          "version": "1.1.1",
-          "from": "isemail@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
-        },
         "topo": {
           "version": "1.0.2",
           "from": "topo@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.2.tgz"
+        },
+        "isemail": {
+          "version": "1.1.1",
+          "from": "isemail@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz"
         }
       }
     },
@@ -2382,16 +1777,6 @@
           "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "minimatch": {
               "version": "0.2.14",
               "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
@@ -2408,6 +1793,16 @@
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
@@ -2460,12 +1855,10 @@
     "mozlog": {
       "version": "2.0.2",
       "from": "mozlog@2.0.2",
-      "resolved": "https://registry.npmjs.org/mozlog/-/mozlog-2.0.2.tgz",
       "dependencies": {
         "intel": {
           "version": "1.0.2",
-          "from": "intel@1.0.2",
-          "resolved": "https://registry.npmjs.org/intel/-/intel-1.0.2.tgz",
+          "from": "intel@^1.0.0",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
@@ -2567,11 +1960,6 @@
               "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "isarray": {
               "version": "0.0.1",
               "from": "isarray@0.0.1",
@@ -2581,6 +1969,11 @@
               "version": "0.10.31",
               "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
@@ -2679,13 +2072,42 @@
       }
     },
     "nock": {
-      "version": "0.48.2",
-      "from": "nock@0.48.2",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-0.48.2.tgz",
+      "version": "2.17.0",
+      "from": "nock@",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-2.17.0.tgz",
       "dependencies": {
+        "chai": {
+          "version": "3.4.1",
+          "from": "chai@>=1.9.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.4.1.tgz",
+          "dependencies": {
+            "assertion-error": {
+              "version": "1.0.1",
+              "from": "assertion-error@^1.0.1",
+              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
+            },
+            "deep-eql": {
+              "version": "0.1.3",
+              "from": "deep-eql@^0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+              "dependencies": {
+                "type-detect": {
+                  "version": "0.1.1",
+                  "from": "type-detect@0.1.1",
+                  "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+                }
+              }
+            },
+            "type-detect": {
+              "version": "1.0.0",
+              "from": "type-detect@^1.0.0",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+            }
+          }
+        },
         "debug": {
           "version": "1.0.4",
-          "from": "debug@>=1.0.4 <2.0.0",
+          "from": "debug@^1.0.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
@@ -2695,6 +2117,11 @@
             }
           }
         },
+        "deep-equal": {
+          "version": "1.0.1",
+          "from": "deep-equal@^1.0.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+        },
         "lodash": {
           "version": "2.4.1",
           "from": "lodash@2.4.1",
@@ -2702,7 +2129,7 @@
         },
         "propagate": {
           "version": "0.3.1",
-          "from": "propagate@>=0.3.0 <0.4.0",
+          "from": "propagate@0.3.x",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         }
       }
@@ -2717,11 +2144,6 @@
       "from": "request@2.47.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.47.0.tgz",
       "dependencies": {
-        "aws-sign2": {
-          "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-        },
         "bl": {
           "version": "0.9.4",
           "from": "bl@>=0.9.0 <0.10.0",
@@ -2737,11 +2159,6 @@
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
@@ -2751,6 +2168,11 @@
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -2760,18 +2182,6 @@
           "version": "0.6.0",
           "from": "caseless@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "from": "combined-stream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "dependencies": {
-            "delayed-stream": {
-              "version": "0.0.5",
-              "from": "delayed-stream@0.0.5",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-            }
-          }
         },
         "forever-agent": {
           "version": "0.5.2",
@@ -2783,64 +2193,15 @@
           "from": "form-data@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
-            "async": {
-              "version": "0.9.0",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            },
             "mime": {
               "version": "1.2.11",
               "from": "mime@>=1.2.11 <1.3.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-            }
-          }
-        },
-        "hawk": {
-          "version": "1.1.1",
-          "from": "hawk@1.1.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-          "dependencies": {
-            "boom": {
-              "version": "0.4.2",
-              "from": "boom@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
-            "cryptiles": {
-              "version": "0.2.2",
-              "from": "cryptiles@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-            },
-            "hoek": {
-              "version": "0.9.1",
-              "from": "hoek@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-            },
-            "sntp": {
-              "version": "0.2.4",
-              "from": "sntp@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-            }
-          }
-        },
-        "http-signature": {
-          "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "dependencies": {
-            "asn1": {
-              "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-            },
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "ctype": {
-              "version": "0.5.3",
-              "from": "ctype@0.5.3",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             }
           }
         },
@@ -2859,20 +2220,15 @@
           "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
         },
-        "oauth-sign": {
-          "version": "0.4.0",
-          "from": "oauth-sign@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
-        },
         "qs": {
           "version": "2.3.3",
           "from": "qs@>=2.3.1 <2.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
-        "stringstream": {
-          "version": "0.0.4",
-          "from": "stringstream@>=0.0.4 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+        "tunnel-agent": {
+          "version": "0.4.0",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
@@ -2886,10 +2242,81 @@
             }
           }
         },
-        "tunnel-agent": {
+        "http-signature": {
+          "version": "0.10.1",
+          "from": "http-signature@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+            },
+            "ctype": {
+              "version": "0.5.3",
+              "from": "ctype@0.5.3",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+            }
+          }
+        },
+        "oauth-sign": {
           "version": "0.4.0",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+          "from": "oauth-sign@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "from": "hawk@1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+            },
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.4",
+          "from": "stringstream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "from": "combined-stream@>=0.0.5 <0.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "dependencies": {
+            "delayed-stream": {
+              "version": "0.0.5",
+              "from": "delayed-stream@0.0.5",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+            }
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "load-grunt-tasks": "^1.0.0",
     "mkdirp": "^0.5.0",
     "mocha-text-cov": "^0.1.0",
-    "nock": "^0.48.0",
+    "nock": "^2.17.0",
     "pngparse": "2.0.1",
     "rimraf": "^2.4.3",
     "through": "^2.3.4",

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -24,7 +24,6 @@ module.exports = function mock(options) {
   const TOKEN_GOOD = JSON.stringify({
     user: options.userid,
     scope: ['profile'],
-    email: 'user@example.domain'
   });
 
   const MOCK_ID = new Array(33).join('f');
@@ -118,14 +117,18 @@ module.exports = function mock(options) {
     tokenGood: function tokenGood() {
       var parts = url.parse(config.get('oauth.url'));
       return nock(parts.protocol + '//' + parts.host)
-        .post(parts.path + '/verify')
+        .post(parts.path + '/verify', function(body) {
+          return body.email === false;
+        })
         .reply(200, TOKEN_GOOD);
     },
 
     token: function token(tok) {
       var parts = url.parse(config.get('oauth.url'));
       return nock(parts.protocol + '//' + parts.host)
-        .post(parts.path + '/verify')
+        .post(parts.path + '/verify', function(body) {
+          return body.email === false;
+        })
         .reply(200, JSON.stringify(tok));
     },
 
@@ -135,6 +138,22 @@ module.exports = function mock(options) {
         .post(parts.path + '/verify')
         .reply(500);
 
+    },
+
+    email: function mockEmail(email) {
+      var parts = url.parse(config.get('authServer.url'));
+      return nock(parts.protocol + '//' + parts.host)
+        .get(parts.path + '/account/profile')
+        .reply(200, {
+          email: email
+        });
+    },
+
+    emailFailure: function mockEmailFailure() {
+      var parts = url.parse(config.get('authServer.url'));
+      return nock(parts.protocol + '//' + parts.host)
+        .get(parts.path + '/account/profile')
+        .reply(500);
     },
 
     workerFailure: function workerFailure(action, bytes) {


### PR DESCRIPTION
This re-applies #166 with a slight change, storing the oauth token in `req.auth.credentials` rather than as a separate property `req.token`.  This is a bit hacky, appears to be enough to make it available to sub-requests that bypass auth checking.  @seanmonstar r?

Fixes #165.