### PR TITLE
chore(convict): use .getProperties(), not deprecated .root()

### DIFF
--- a/bin/_static.js
+++ b/bin/_static.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const config = require('../lib/config').root();
+const config = require('../lib/config').getProperties();
 const logger = require('../lib/logging')('bin._static');
 const server = require('../lib/server/_static').create();
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const config = require('../lib/config').root();
+const config = require('../lib/config').getProperties();
 const db = require('../lib/db');
 const events = require('../lib/events');
 const logger = require('../lib/logging')('bin.server');


### PR DESCRIPTION
Just cleaning up deprecation warnings in logs. r? - @seanmonstar