### PR TITLE
feat(mysql): Ensure db connections always run in strict mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "npmshrink": "1.0.1",
     "pngparse": "2.0.1",
     "rimraf": "2.5.3",
+    "sinon": "1.17.5",
     "through": "2.3.8",
     "time-grunt": "1.3.0"
   },

--- a/test/mysql.js
+++ b/test/mysql.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*global describe,it,beforeEach*/
+
+const assert = require('insist');
+const sinon = require('sinon');
+
+const MysqlStore = require('../lib/db/mysql');
+
+describe('mysql db backend', function() {
+
+  var store;
+  var mockConnection;
+  var mockResponses;
+  var capturedQueries;
+
+  beforeEach(function() {
+    capturedQueries = [];
+    mockResponses = [];
+    mockConnection = {
+      release: sinon.spy(),
+      ping: sinon.spy(function(cb) { return cb(); }),
+      query: sinon.spy(function (q, cb) {
+        capturedQueries.push(q);
+        return cb.apply(undefined, mockResponses[capturedQueries.length - 1]);
+      })
+    };
+    store = new MysqlStore({});
+    sinon.stub(store._pool, 'getConnection', function(cb) {
+      cb(null, mockConnection);
+    });
+  });
+
+  it('should force new connections into strict mode', function() {
+    mockResponses.push([null, [{ mode: 'DUMMY_VALUE,NO_ENGINE_SUBSTITUTION' }]]);
+    mockResponses.push([null, []]);
+    return store.ping().then(function() {
+      assert.equal(capturedQueries.length, 2);
+      // The first query is checking the sql_mode.
+      assert.equal(capturedQueries[0], 'SELECT @@sql_mode AS mode');
+      // The second query is to set the sql_mode.
+      assert.equal(capturedQueries[1], 'SET SESSION sql_mode = \'DUMMY_VALUE,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES\'');
+    }).then(function() {
+      // But re-using the connection a second time
+      return store.ping();
+    }).then(function() {
+      // Should not re-issue the strict-mode queries.
+      assert.equal(capturedQueries.length, 2);
+    });
+  });
+
+  it('should not mess with connections that already have strict mode', function() {
+    mockResponses.push([null, [{ mode: 'STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION' }]]);
+    return store.ping().then(function() {
+      assert.equal(capturedQueries.length, 1);
+      // The only query is to check the sql_mode.
+      assert.equal(capturedQueries[0], 'SELECT @@sql_mode AS mode');
+    });
+  });
+
+  it('should propagate any errors that happen when setting the mode', function() {
+    mockResponses.push([null, [{ mode: 'SOME_NONSENSE_DEFAULT' }]]);
+    mockResponses.push([new Error('failed to set mode')]);
+    return store.ping().then(function() {
+      assert.fail('the ping attempt should have failed');
+    }).catch(function(err) {
+      assert.equal(capturedQueries.length, 2);
+      assert.equal(err.message, 'failed to set mode');
+    });
+  });
+});


### PR DESCRIPTION
This was an idea I had to enforce mysql strict mode and utf8mb4 on all db connections.  It's possible (and advisable!) to set these defaults in the MySQL server itself, but we can also enforce them here as an additional layer of protection.

No tests yet, because we don't have any test infra for mocking out MySQL in this repo.

@jrgm @vladikoff thoughts?