### PR TITLE
Add security headers

### DIFF
--- a/lib/server/web.js
+++ b/lib/server/web.js
@@ -51,7 +51,7 @@ exports.create = function createServer() {
             includeSubdomains: true
           },
           xframe: false,
-          xss: false,
+          xss: true,
           noOpen: false,
           noSniff: true
         }

--- a/lib/server/web.js
+++ b/lib/server/web.js
@@ -50,7 +50,7 @@ exports.create = function createServer() {
             maxAge: 15552000,
             includeSubdomains: true
           },
-          xframe: false,
+          xframe: true,
           xss: true,
           noOpen: false,
           noSniff: true

--- a/lib/server/web.js
+++ b/lib/server/web.js
@@ -53,7 +53,7 @@ exports.create = function createServer() {
           xframe: false,
           xss: false,
           noOpen: false,
-          noSniff: false
+          noSniff: true
         }
       }
     }

--- a/test/server.js
+++ b/test/server.js
@@ -28,10 +28,13 @@ describe('server', function() {
         var xssHeader = res.headers['x-xss-protection'];
         assert.equal(xssHeader, '1; mode=block');
 
+        // frame options header
+        var frameHeader = res.headers['x-frame-options'];
+        assert.equal(frameHeader, 'DENY');
+
         // but the other security builtin headers from hapi are not set
         var other = {
           'x-download-options': 1,
-          'x-frame-options': 1,
         };
 
         Object.keys(res.headers).forEach(function(header) {
@@ -65,4 +68,3 @@ describe('server', function() {
     });
   });
 });
-

--- a/test/server.js
+++ b/test/server.js
@@ -24,11 +24,14 @@ describe('server', function() {
         var contentTypeHeader = res.headers['x-content-type-options'];
         assert.equal(contentTypeHeader, 'nosniff');
 
+        // xss protection header
+        var xssHeader = res.headers['x-xss-protection'];
+        assert.equal(xssHeader, '1; mode=block');
+
         // but the other security builtin headers from hapi are not set
         var other = {
           'x-download-options': 1,
           'x-frame-options': 1,
-          'x-xss-protection': 1
         };
 
         Object.keys(res.headers).forEach(function(header) {

--- a/test/server.js
+++ b/test/server.js
@@ -20,9 +20,12 @@ describe('server', function() {
         var stsHeader = res.headers['strict-transport-security'];
         assert.equal(stsHeader, 'max-age=15552000; includeSubDomains');
 
+        // content type options header
+        var contentTypeHeader = res.headers['x-content-type-options'];
+        assert.equal(contentTypeHeader, 'nosniff');
+
         // but the other security builtin headers from hapi are not set
         var other = {
-          'x-content-type-options': 1,
           'x-download-options': 1,
           'x-frame-options': 1,
           'x-xss-protection': 1


### PR DESCRIPTION
Same changes as: https://github.com/mozilla/fxa-oauth-server/pull/437

Add security headers (see also the commit messages).

I'm assuming these API endpoints aren't iframed anywhere.

We discussed having the webserver send these, but having this in code allows it to be tested and makes dev and prod environments more similar. Both of those things make @jrgm happy (per https://github.com/mozilla-services/cloudops-deployment/pull/334#issuecomment-270717289).