### PR TITLE
fix(config): only force this settting if it's the default value

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -266,7 +266,8 @@ var files = (envConfig + ',' + process.env.CONFIG_FILES)
   .split(',').filter(fs.existsSync);
 conf.loadFile(files);
 
-if (conf.get('img.driver') === 'local') {
+if (conf.get('img.driver') === 'local' &&
+    conf.get('img.uploads.dest.public') === 'BUCKET_NAME') {
   conf.set('img.uploads.dest.public',
     path.join(__dirname, '..', 'var', 'public'));
 }


### PR DESCRIPTION
Maybe this needs an overally cleanup, but right now, this unblocks overriding of the `img.uploads.dest.public` config when using local image driver.

r? - @seanmonstar