### PR TITLE
fix(startup): exit if server.start() returns an error

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -16,7 +16,8 @@ logger.info('config', config);
 db.ping().done(function() {
   server.start(function(err) {
     if (err) {
-      logger.error('server.start', err);
+      logger.critical('server.start', err);
+      process.exit(1);
     }
     logger.info('listening', server.info.uri);
   });


### PR DESCRIPTION
If we've failed the LISTEN, don't report "listening". Exit.

r? - @seanmonstar 