### PR TITLE
fix(buffer): #309 Clean up 'Buffer' calls to deprecated API

### DIFF
--- a/lib/compute/image-cc.js
+++ b/lib/compute/image-cc.js
@@ -58,7 +58,7 @@ function compute(msg, callback) {
   var id = msg.id;
   var variant = msg.suffix || 'default';
   var suffix = msg.suffix ? '_' + msg.suffix : '';
-  var src = Buffer(msg.payload);
+  var src = Buffer.from(msg.payload);
   var start = Date.now();
   var s3Start = start;
   logger.debug('process.start', { bytes: src.length, variant: variant });

--- a/test/api.js
+++ b/test/api.js
@@ -569,7 +569,7 @@ describe('/avatar', function() {
 
       return Server.api.post({
         url: '/avatar/upload',
-        payload: Buffer('{}'),
+        payload: Buffer.from('{}'),
         headers: { authorization: 'Bearer ' + tok,
           'content-type': 'image/png',
           'content-length': dataLength

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -58,7 +58,7 @@ module.exports = function mock(options) {
         return inject(WORKER, {
           method: 'POST',
           url: path,
-          payload: Buffer(body, 'hex'),
+          payload: Buffer.from(body, 'hex'),
           headers: headers
         });
       });


### PR DESCRIPTION
Fixes for #309 Clean up 'Buffer' calls to deprecated API