### PR TITLE
fix(test): Avoid cross test pollution caused by mutating route objects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hapi": "16.6.3",
     "inert": "4.0.2",
     "joi": "9.0.4",
+    "lodash.clonedeep": "4.5.0",
     "mozlog": "2.2.0",
     "mysql": "2.16.0",
     "mysql-patcher": "0.7.0",


### PR DESCRIPTION
This is to help @deeptibaghel with #334. I added a ton of logging to Deepti's PR and Hapi and noticed that a route's `scope` value was being updated for every test suite, the next test suite would then use the implicant values from the previous suite as it's scopes.

This makes a copy of the route definition which is safe to mutate. Still a WIP because I would expect tests to be failing on master too, and I'm not sure why they aren't.

cc @rfk, @vladikoff, @deeptibaghel 