### PR TITLE
feat(profile): invalidate cache when profileChangedAt when needed

### DIFF
--- a/lib/routes/_core_profile.js
+++ b/lib/routes/_core_profile.js
@@ -27,7 +27,8 @@ module.exports = {
       email: Joi.string().optional(),
       locale: Joi.string().optional(),
       amrValues: Joi.array().items(Joi.string().required()).optional(),
-      twoFactorAuthentication: Joi.boolean().optional()
+      twoFactorAuthentication: Joi.boolean().optional(),
+      profileChangedAt: Joi.number().optional()
     }
   },
   handler: function _core_profile(req, reply) {
@@ -83,6 +84,9 @@ module.exports = {
       }
       if (typeof body.authenticatorAssuranceLevel !== 'undefined') {
         result.twoFactorAuthentication = body.authenticatorAssuranceLevel >= 2;
+      }
+      if (typeof body.profileChangedAt !== 'undefined') {
+        result.profileChangedAt = body.profileChangedAt;
       }
       reply(result);
     });

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -149,6 +149,16 @@ module.exports = function mock(options) {
         });
     },
 
+    profileChangedAt: function mockProfileChangedAt(email, profileChangedAt) {
+      var parts = url.parse(config.get('authServer.url'));
+      return nock(parts.protocol + '//' + parts.host)
+        .get(parts.path + '/account/profile')
+        .reply(200, {
+          email: email,
+          profileChangedAt
+        });
+    },
+
     emailFailure: function mockEmailFailure(body) {
       body = body || {};
       var parts = url.parse(config.get('authServer.url'));


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-auth-server/issues/2490

This PR will invalidate a user's profile cache whenever auth-server reports a new `profileChangedAt` value (via oauth token), than what is stored in the cache it self.