### PR TITLE
fix(logs): unwrap nested errors in img-worker log

### DIFF
--- a/lib/img-workers.js
+++ b/lib/img-workers.js
@@ -41,7 +41,7 @@ exports.upload = function upload(id, payload, headers) {
       }
 
       if (res.statusCode >= 400 || (body && body.error) || nestedError) {
-        logger.error('upload.worker.error', body);
+        logger.error('upload.worker.error', nestedError || body);
         reject(AppError.processingError(body));
         return;
       }

--- a/test/api.js
+++ b/test/api.js
@@ -735,12 +735,12 @@ describe('/avatar', function() {
         user: USERID,
         scope: ['profile:avatar:write']
       });
-      mock.workerFailure('post', imageData.length);
+      mock.workerFailure('post', imageData.length, [ { error: 'wibble' } ]);
       mock.log('img_workers', function(rec) {
         if (rec.levelname === 'ERROR') {
           assert.equal(
             rec.message,
-            'upload.worker.error unexpected server error'
+            'upload.worker.error wibble'
           );
           return true;
         }

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -174,7 +174,7 @@ module.exports = function mock(options) {
         .reply(200, body);
     },
 
-    workerFailure: function workerFailure(action, bytes) {
+    workerFailure: function workerFailure(action, bytes, response) {
       if (action !== 'post' && action !== 'delete') {
         throw new Error('failure must be post or delete');
       }
@@ -191,7 +191,7 @@ module.exports = function mock(options) {
       })
         .filteringPath(/^\/a\/[0-9a-f]{32}$/g, '/a/' + MOCK_ID)
         [action]('/a/' + MOCK_ID) // eslint-disable-line no-unexpected-multiline
-        .reply(500, 'unexpected server error');
+        .reply(500, response || 'unexpected server error');
 
     },
 


### PR DESCRIPTION
Fixes #392?

Not sure if I've done the right thing here or not, because I couldn't see how to make the test respond with an array (or just an object with numeric keys). I know I'm looking in `test/lib/mock.js`, but I got lost trying to follow the request/response path. So probably this needs more work before it's ok to merge, if so some tips on testing would be appreciated.

I *think* I'm changing the correct log message based on the description in the issue though.

@mozilla/fxa-devs r?/help?